### PR TITLE
fixed Printable import

### DIFF
--- a/mppca/multiprocess.py
+++ b/mppca/multiprocess.py
@@ -7,14 +7,13 @@ import numpy as np
 from joblib import Parallel, delayed
 from typing import Iterable, Callable
 
-from herl.utils import Printable
+from mppca.utils import Printable
 
 import numpy as np
 
 from joblib import Parallel, delayed
 from typing import Iterable, Callable
 
-from herl.utils import Printable
 
 
 class MultiProcess(Printable):


### PR DESCRIPTION
herl is not included in the repository nor installed with it. However, copy of required code is in mppca.utils, so I suppose the import is faulty.